### PR TITLE
Fix handler typos

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -510,20 +510,20 @@ export function handleProcessGuildKickProposal(event:ProcessGuildKickProposal):v
 }
 
 // event Ragequit(address indexed memberAddress, uint256 sharesToBurn, uint256 lootToBurn);
-// handler: handleProcessWhitelistProposal
+// handler: handleRagequit
 export function handleRagequit(event:Ragequit):void{
   
 }
 
 // event CancelProposal(uint256 indexed proposalIndex, address applicantAddress);
-// handler: handleProcessWhitelistProposal
+// handler: handleCancelProposal
 export function handleCancelProposal(event:CancelProposal):void{
 
 }
 
 // event UpdateDelegateKey(address indexed memberAddress, address newDelegateKey);
-// handler: handleProcessWhitelistProposal
-export function updateDelegateKey(event:CancelProposal):void{
+// handler: handleUpdateDelegateKey
+export function handleUpdateDelegateKey(event:UpdateDelegateKey):void{
   
 }
 


### PR DESCRIPTION
resolves https://github.com/daodesigner/moloch-subgraph/issues/13

Rename to handleUpdateDelegateKey in the mapping.ts file.

Just so it matches the subgraph.yml

    - event: UpdateDelegateKey(indexed address,address)
      handler: handleUpdateDelegateKey

Otherwise it'll fail when syncing if that event is there.